### PR TITLE
fix: get docker working

### DIFF
--- a/Docker/docker-compose-dev.yml
+++ b/Docker/docker-compose-dev.yml
@@ -55,7 +55,6 @@ services:
       dockerfile: Docker/Frontend.dev.Dockerfile
     volumes:
       - ../frontend:/xplored/frontend
-      - /xplored/frontend/node_modules
   gateway:
     tty: true
     stdin_open: true


### PR DESCRIPTION
hotfix to prevent nod modules from caching in development mode of the docker compose